### PR TITLE
fix: kiuwan issues

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.elevenpaths.almaraz</groupId>
 	<artifactId>almaraz-example</artifactId>
-	<version>0.2.5</version>
+	<version>0.2.6</version>
 	<name>almaraz-example</name>
 	<description>Example of a WebFlux server leveraging almaraz</description>
 
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.elevenpaths.almaraz</groupId>
 			<artifactId>almaraz</artifactId>
-			<version>0.2.5</version>
+			<version>0.2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>net.logstash.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.elevenpaths.almaraz</groupId>
 	<artifactId>almaraz</artifactId>
-	<version>0.2.5</version>
+	<version>0.2.6</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/elevenpaths/almaraz/context/RequestContext.java
+++ b/src/main/java/com/elevenpaths/almaraz/context/RequestContext.java
@@ -214,7 +214,7 @@ public class RequestContext {
 	public Long getLong(String key) {
 		try {
 			return Long.valueOf(getString(key));
-		} catch (Exception e) {
+		} catch (NullPointerException | NumberFormatException e) {
 			return null;
 		}
 	}
@@ -239,11 +239,8 @@ public class RequestContext {
 	 * @return Value of the context property as {@link Boolean}.
 	 */
 	public Boolean getBoolean(String key) {
-		try {
-			return Boolean.valueOf(getString(key));
-		} catch (Exception e) {
-			return null;
-		}
+		String value = getString(key);
+		return value == null ? null : Boolean.valueOf(getString(key));
 	}
 
 	/**

--- a/src/main/java/com/elevenpaths/almaraz/context/RequestContext.java
+++ b/src/main/java/com/elevenpaths/almaraz/context/RequestContext.java
@@ -239,8 +239,8 @@ public class RequestContext {
 	 * @return Value of the context property as {@link Boolean}.
 	 */
 	public Boolean getBoolean(String key) {
-		String value = getString(key);
-		return value == null ? null : Boolean.valueOf(getString(key));
+		return Boolean.valueOf(getString(key));
+
 	}
 
 	/**

--- a/src/main/java/com/elevenpaths/almaraz/logging/MDCServerWebExchange.java
+++ b/src/main/java/com/elevenpaths/almaraz/logging/MDCServerWebExchange.java
@@ -41,7 +41,7 @@ public class MDCServerWebExchange {
 	public static String getMethod(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getMethodValue();
-		} catch (Exception e) {
+		} catch (NullPointerException e) {
 			return null;
 		}
 	}
@@ -55,7 +55,7 @@ public class MDCServerWebExchange {
 	public static String getPath(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getPath().value();
-		} catch (Exception e) {
+		} catch (NullPointerException e) {
 			return null;
 		}
 	}
@@ -86,7 +86,7 @@ public class MDCServerWebExchange {
 	public static String getRemoteAddressFromTCP(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getRemoteAddress().getAddress().toString();
-		} catch (Exception e) {
+		} catch (NullPointerException e) {
 			return null;
 		}
 	}
@@ -102,7 +102,7 @@ public class MDCServerWebExchange {
 	public static String getRemoteAddressFromXFF(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getHeaders().getValuesAsList(X_FORWARDED_FOR_HEADER).get(0);
-		} catch (Exception e) {
+		} catch (NullPointerException | IndexOutOfBoundsException e) {
 			return null;
 		}
 	}
@@ -116,7 +116,7 @@ public class MDCServerWebExchange {
 	public static String getStatusCode(ServerWebExchange exchange) {
 		try {
 			return Integer.toString(exchange.getResponse().getStatusCode().value());
-		} catch (Exception e) {
+		} catch (NullPointerException e) {
 			return null;
 		}
 	}

--- a/src/main/java/com/elevenpaths/almaraz/logging/MDCServerWebExchange.java
+++ b/src/main/java/com/elevenpaths/almaraz/logging/MDCServerWebExchange.java
@@ -41,7 +41,7 @@ public class MDCServerWebExchange {
 	public static String getMethod(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getMethodValue();
-		} catch (NullPointerException e) {
+		} catch (Exception e) {
 			return null;
 		}
 	}
@@ -55,7 +55,7 @@ public class MDCServerWebExchange {
 	public static String getPath(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getPath().value();
-		} catch (NullPointerException e) {
+		} catch (Exception e) {
 			return null;
 		}
 	}
@@ -86,7 +86,7 @@ public class MDCServerWebExchange {
 	public static String getRemoteAddressFromTCP(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getRemoteAddress().getAddress().toString();
-		} catch (NullPointerException e) {
+		} catch (Exception e) {
 			return null;
 		}
 	}
@@ -102,7 +102,7 @@ public class MDCServerWebExchange {
 	public static String getRemoteAddressFromXFF(ServerWebExchange exchange) {
 		try {
 			return exchange.getRequest().getHeaders().getValuesAsList(X_FORWARDED_FOR_HEADER).get(0);
-		} catch (NullPointerException | IndexOutOfBoundsException e) {
+		} catch (Exception e) {
 			return null;
 		}
 	}
@@ -116,7 +116,7 @@ public class MDCServerWebExchange {
 	public static String getStatusCode(ServerWebExchange exchange) {
 		try {
 			return Integer.toString(exchange.getResponse().getStatusCode().value());
-		} catch (NullPointerException e) {
+		} catch (Exception e) {
 			return null;
 		}
 	}

--- a/src/main/java/com/elevenpaths/almaraz/resolvers/ValidRequestBodyResolver.java
+++ b/src/main/java/com/elevenpaths/almaraz/resolvers/ValidRequestBodyResolver.java
@@ -131,7 +131,7 @@ public class ValidRequestBodyResolver implements HandlerMethodArgumentResolver {
 						JsonNode node = objectMapper.valueToTree(formData);
 						return validateAndMarshal(schemaName, node, valueType);
 					} catch (IOException e) {
-						throw new InvalidRequestException("invalid urlencoded body", e);
+						throw new InvalidRequestException("invalid urlencoded body");
 					}
 				});
 	}
@@ -153,7 +153,7 @@ public class ValidRequestBodyResolver implements HandlerMethodArgumentResolver {
 				}
 				return validateAndMarshal(schemaName, node, valueType);
 			} catch (IOException e) {
-				throw new InvalidRequestException("invalid json body", e);
+				throw new InvalidRequestException("invalid json body");
 			}
 		});
 	}
@@ -173,7 +173,7 @@ public class ValidRequestBodyResolver implements HandlerMethodArgumentResolver {
 			JsonNode node = objectMapper.valueToTree(multi ? queryParams : toSingleValueMap(queryParams));
 			return Mono.just(validateAndMarshal(schemaName, node, valueType));
 		} catch (IOException e) {
-			throw new InvalidRequestException("invalid query params", e);
+			throw new InvalidRequestException("invalid query params");
 		}
 
 	}

--- a/src/main/java/com/elevenpaths/almaraz/validation/JsonSchemaRepository.java
+++ b/src/main/java/com/elevenpaths/almaraz/validation/JsonSchemaRepository.java
@@ -2,11 +2,13 @@
 
 package com.elevenpaths.almaraz.validation;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaException;
 import com.networknt.schema.JsonSchemaFactory;
 
 /**
@@ -55,7 +57,7 @@ public class JsonSchemaRepository {
 				throw new JsonSchemaRepositoryException("Schema not found: " + schemaPath);
 			}
 			return JsonSchemaFactory.getInstance().getSchema(is);
-		} catch (Exception e) {
+		} catch (JsonSchemaException | IOException e) {
 			throw new JsonSchemaRepositoryException("Invalid schema: " + schemaPath, e);
 		}
 	}


### PR DESCRIPTION
Resolves the following kiuwan issues:

- Avoid Exception, RuntimeException o Throwable in catch or throw statements.
- Avoid sensitive information exposure through error messages.

The following issues have been muted:

- URL Redirection to Untrusted Site ('Open Redirect') in [CompleteLocationHeaderWebFilter.java-L41](https://github.com/Telefonica/almaraz/blob/master/src/main/java/com/elevenpaths/almaraz/webfilters/CompleteLocationHeaderWebFilter.java#L41) because Almaraz doesn't know how to validate all the resources.
- All the [almaraz/example](https://github.com/Telefonica/almaraz/tree/master/example) issues have been muted.
- Some Exceptions can't be specified because ServerWebExchange is an interface.
